### PR TITLE
Updated npm package main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-vault",
   "version": "0.5.0",
   "description": "Javascript client for HashiCorp's Vault",
-  "main": "./lib/node-vault.js",
+  "main": "./src/index.js",
   "scripts": {
     "test": "_mocha --recursive",
     "cov": "istanbul cover _mocha -- test/",


### PR DESCRIPTION
[Issue 24](https://github.com/kr1sp1n/node-vault/issues/24) details requiring the `node-vault` npm failing because the entry point is a file that no longer exists.

This pull requests updates `main` to `index.js`. As there is no longer a build script I'm assuming this is the correct entry point.