### PR TITLE
Add list method to enumerate keys of path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,14 @@ module.exports = (config = {}) => {
     return client.request(options).then(handleVaultResponse);
   };
 
+  client.list = (path, requestOptions) => {
+    debug(`list ${path}`);
+    const options = Object.assign({}, config.requestOptions, requestOptions);
+    options.path = `/${path}`;
+    options.method = 'LIST';
+    return client.request(options).then(handleVaultResponse);
+  };
+
   client.delete = (path, requestOptions) => {
     debug(`delete ${path}`);
     const options = Object.assign({}, config.requestOptions, requestOptions);


### PR DESCRIPTION
Reference: https://www.vaultproject.io/docs/http/index.html

> You can list secrets as well. To do this, either issue a GET with the query parameter list=true, or you can use the LIST HTTP verb. For the generic backend, listing is allowed on directories only, and returns the keys in the given directory