### PR TITLE
Error response improvements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,13 @@ module.exports = (config = {}) => {
   function handleVaultResponse(response) {
     // debug(response.statusCode);
     if (response.statusCode !== 200 && response.statusCode !== 204) {
-      return Promise.reject(new Error(response.body.errors[0]));
+      let message;
+      if (response.body.errors && response.body.errors.length > 0) {
+        message = response.body.errors[0];
+      } else {
+        message = `Status ${response.statusCode}`;
+      }
+      return Promise.reject(new Error(message));
     }
     return Promise.resolve(response.body);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,9 @@ module.exports = (config = {}) => {
       } else {
         message = `Status ${response.statusCode}`;
       }
-      return Promise.reject(new Error(message));
+      const error = new Error(message);
+      error.response = response;
+      return Promise.reject(error);
     }
     return Promise.resolve(response.body);
   }


### PR DESCRIPTION
This PR adds support for handling errors that do not return an `errors` array (for endpoints and methods that don't return a JSON body at all) and includes the response object as a `response` property of the `Error` object (e.g. for error handling based on specific status codes).