### PR TITLE
Paths with "health" in them return the body even on error conditions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ module.exports = (config = {}) => {
     debug(response.statusCode);
     if (response.statusCode !== 200 && response.statusCode !== 204) {
       // handle health response not as error
-      if (response.request.path.match(/health/) !== null) {
+      if (response.request.path.match(/sys\/health/) !== null) {
         return Promise.resolve(response.body);
       }
       let message;

--- a/test/unit.js
+++ b/test/unit.js
@@ -241,6 +241,22 @@ describe('node-vault', () => {
         });
       });
 
+      it('should return error if error on request path with health and not sys/health', done => {
+        response.statusCode = 404;
+        response.body = {
+          errors: [],
+        };
+        response.request = {
+          path: '/v1/sys/policies/applications/im-not-sys-health/app',
+        };
+        vault.handleVaultResponse(response)
+        .then(() => done(error))
+        .catch(err => {
+          err.message.should.equal(`Status ${response.statusCode}`);
+          return done();
+        });
+      });
+
       it('should return a Promise with the error if no response is passed', done => {
         const promise = vault.handleVaultResponse();
         promise.catch((err) => {


### PR DESCRIPTION
We noticed an issue when attempting to check for an app policy where the app had the word "health" in it.

We were using the getPolicy command to lookup an app to determine whether it had been created and the error condition was not firing, resulting in the app being incorrectly identified as an existing app.

I've provided the solution and a unit test to validate it.

Thanks very much.