### PR TITLE
Don't include request or response body in errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,6 @@ module.exports = (config = {}) => {
         message = `Status ${response.statusCode}`;
       }
       const error = new Error(message);
-      error.response = response;
       return Promise.reject(error);
     }
     return Promise.resolve(response.body);


### PR DESCRIPTION
The response object includes the request details and can potentially cause Vault tokens to be logged in plain text on insecure systems.

Resolves #50.