### PR TITLE
Fixes url for lease renew and revoke

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -297,11 +297,50 @@ module.exports = {
   },
   renew: {
     method: 'PUT',
-    path: '/sys/renew/{{lease_id}}',
+    path: '/sys/leases/renew',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+          increment: {
+            type: 'integer'
+          }
+        },
+        required: ['lease_id'],
+      },
+      res: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+          renewable: {
+            type: 'boolean',
+          },
+          lease_duration: {
+            type: 'integer',
+          },
+        },
+      }
+    },
   },
   revoke: {
     method: 'PUT',
-    path: '/sys/revoke/{{lease_id}}',
+    path: '/sys/leases/revoke',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+        },
+        required: ['lease_id'],
+      },
+    },
   },
   revokePrefix: {
     method: 'PUT',


### PR DESCRIPTION
According to the latest [documentation](https://www.vaultproject.io/api/system/leases.html) the endpoints for lease renewal and revocation should be different.

However, I was not able to test this fix due to [this bug](https://github.com/hashicorp/vault/issues/2875). It may be my incorrect usage or wrong environment though, so feel free to close this pull request and reimplement the functionality as needed.

Am I targeting the correct branch `master`? Or the pull requests should be opened against `develop`?

Thank you,
Artiom