### PR TITLE
Fix typo tokenLookupAccesspr

### DIFF
--- a/example/token.js
+++ b/example/token.js
@@ -4,19 +4,14 @@ process.env.DEBUG = 'node-vault'; // switch on debug mode
 
 const vault = require('./../src/index')();
 
-let new_token
-
 vault.tokenCreate()
 .then((result) => {
-	console.log(result)
-	new_token = result.auth
-	return vault.tokenLookup({token: new_token.client_token})
+  console.log(result);
+  const newToken = result.auth;
+  return vault.tokenLookup({ token: newToken.client_token })
+  .then(() => vault.tokenLookupAccessor({ accessor: newToken.accessor }));
 })
 .then((result) => {
-	console.log(result)
-	return vault.tokenLookupAccessor({accessor: new_token.accessor})
+  console.log(result);
 })
-.then((result) => {
-	console.log(result)
-})
-.catch((err) => console.error(err.message))
+.catch((err) => console.error(err.message));

--- a/example/token.js
+++ b/example/token.js
@@ -1,0 +1,22 @@
+// file: example/token.js
+
+process.env.DEBUG = 'node-vault'; // switch on debug mode
+
+const vault = require('./../src/index')();
+
+let new_token
+
+vault.tokenCreate()
+.then((result) => {
+	console.log(result)
+	new_token = result.auth
+	return vault.tokenLookup({token: new_token.client_token})
+})
+.then((result) => {
+	console.log(result)
+	return vault.tokenLookupAccessor({accessor: new_token.accessor})
+})
+.then((result) => {
+	console.log(result)
+})
+.catch((err) => console.error(err.message))

--- a/src/commands.js
+++ b/src/commands.js
@@ -524,7 +524,7 @@ module.exports = {
       },
     },
   },
-  tokenLookupAccesspr: {
+  tokenLookupAccessor: {
     method: 'POST',
     path: '/auth/token/lookup-accessor',
     schema: {


### PR DESCRIPTION
Fixes typo on commands entry` tokenLookupAccesspr` to `tokenLookupAccessor`. Adds basic example of token routes as well.