### PR TITLE
Fix promise chain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ module.exports = (config = {}) => {
       if (!conf.schema) return client.request(options);
       // else do validation of request URL and body
       return validate(options.json, conf.schema.req)
-      .then(validate(options.json, conf.schema.query))
+      .then(() => validate(options.json, conf.schema.query))
       .then(() => extendOptions(conf, options))
       .then((extendedOptions) => client.request(extendedOptions));
     };


### PR DESCRIPTION
Fixes #48 `Warning: .then() only accepts functions but was passed: [object Object]`.

Since validate function returns promise, but not a function we need it to wrap into a function.