### PR TITLE
Fix renew and revoke lease

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -324,11 +324,50 @@ module.exports = {
   },
   renew: {
     method: 'PUT',
-    path: '/sys/renew/{{lease_id}}',
+    path: '/sys/leases/renew',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+          increment: {
+            type: 'integer'
+          }
+        },
+        required: ['lease_id'],
+      },
+      res: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+          renewable: {
+            type: 'boolean',
+          },
+          lease_duration: {
+            type: 'integer',
+          },
+        },
+      }
+    },
   },
   revoke: {
     method: 'PUT',
-    path: '/sys/revoke/{{lease_id}}',
+    path: '/sys/leases/revoke',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+        },
+        required: ['lease_id'],
+      },
+    },
   },
   revokePrefix: {
     method: 'PUT',

--- a/src/commands.js
+++ b/src/commands.js
@@ -333,8 +333,8 @@ module.exports = {
             type: 'string',
           },
           increment: {
-            type: 'integer'
-          }
+            type: 'integer',
+          },
         },
         required: ['lease_id'],
       },
@@ -351,7 +351,7 @@ module.exports = {
             type: 'integer',
           },
         },
-      }
+      },
     },
   },
   revoke: {


### PR DESCRIPTION
Currently unable to renew or revoke database credential leases since the API is incorrectly implemented in node-vault. This change fixes the problem.

This fix was original proposed in kr1sp1n/node-vault#52.

See:
https://www.vaultproject.io/api/system/leases.html#renew-lease
https://www.vaultproject.io/api/system/leases.html#revoke-lease