### PR TITLE
Fixed broken token conditional

### DIFF
--- a/features.md
+++ b/features.md
@@ -119,12 +119,12 @@
 
 ## vault.renew
 
-`PUT /sys/renew/{{lease_id}}`
+`PUT /sys/leases/renew`
 
 
 ## vault.revoke
 
-`PUT /sys/revoke/{{lease_id}}`
+`PUT /sys/leases/revoke`
 
 
 ## vault.revokePrefix

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ module.exports = (config = {}) => {
     // Replace unicode encodings.
     uri = uri.replace(/&#x2F;/g, '/');
     options.headers = options.headers || {};
-    if (client.token !== undefined || client.token !== null || client.token !== '') {
+    if (typeof client.token === 'string' && client.token.length) {
       options.headers['X-Vault-Token'] = client.token;
     }
     options.uri = uri;


### PR DESCRIPTION
(check pull request diff)

The condition was malformed in a way that was always returning true. Now it works as I think was originally intended and I also made it more explicit, checking if the token variable contains a string with a length of 1+ characters.