### PR TITLE
Set statusCode in Error object on reject

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ module.exports = (config = {}) => {
         message = `Status ${response.statusCode}`;
       }
       const error = new Error(message);
+      error.statusCode = response.statusCode;
       return Promise.reject(error);
     }
     return Promise.resolve(response.body);


### PR DESCRIPTION
Provides a way for callers to detect specific errors, since the response was removed from the error object.