### PR TITLE
secret_id is no longer required

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -1080,7 +1080,7 @@ module.exports = {
             type: 'string',
           },
         },
-        required: ['role_id', 'secret_id'],
+        required: ['role_id'],
       },
       res: approleResponse,
     },


### PR DESCRIPTION
It is possible to configure AppRoles to not require a secret_id.

https://www.vaultproject.io/docs/auth/approle.html
https://www.vaultproject.io/api/auth/approle/index.html#create-new-approle
https://www.vaultproject.io/api/auth/approle/index.html#login-with-approle

This PR allows `appRoleLogin()` to be used without `secret_id`. 

Tested locally without issue.