### PR TITLE
 support updating vault token for configured commands

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -394,6 +394,7 @@ module.exports = {
   githubLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}github{{/mount_point}}/login',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -410,6 +411,7 @@ module.exports = {
   userpassLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}userpass{{/mount_point}}/login/{{username}}',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -426,6 +428,7 @@ module.exports = {
   ldapLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}ldap{{/mount_point}}/login/{{username}}',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -442,6 +445,7 @@ module.exports = {
   oktaLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}okta{{/mount_point}}/login/{{username}}',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -458,6 +462,7 @@ module.exports = {
   radiusLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}radius{{/mount_point}}/login/{{username}}',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -1069,6 +1074,7 @@ module.exports = {
   approleLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}approle{{/mount_point}}/login',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',


### PR DESCRIPTION
**UPDATE**: For now, I've published `@mpareja/node-vault` containing kubernetes login support (PR #92) and support for retaining the received access token (PR #93 - this one).

---

This PR is a configuration driven version of PR #85.