### PR TITLE
Allow X-Vault-Token header override.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ module.exports = (config = {}) => {
     uri = uri.replace(/&#x2F;/g, '/');
     options.headers = options.headers || {};
     if (typeof client.token === 'string' && client.token.length) {
-      options.headers['X-Vault-Token'] = client.token;
+      options.headers['X-Vault-Token'] = options.headers['X-Vault-Token'] || client.token;
     }
     options.uri = uri;
     debug(options.method, uri);


### PR DESCRIPTION
I have a use-case where I have short lease tokens generated by a userpass auth. I do not want these short lease tokens to be stored in client.token as they will be used quickly and tossed. That said, once those tokens are tossed I have a longer less-privileged token that I want to keep in client.token for most other operations.

This pull-request simply allows the consumer to override the X-Vault-Token for any request.