### PR TITLE
fix(body): set body only if it has keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,8 @@ module.exports = (config = {}) => {
       const options = Object.assign({}, config.requestOptions, args.requestOptions);
       options.method = conf.method;
       options.path = conf.path;
-      options.json = args;
+      // set body only if args exist
+      if (Object.keys(args).length) options.json = args;
       // no schema object -> no validation
       if (!conf.schema) return client.request(options);
       // else do validation of request URL and body


### PR DESCRIPTION
I ran into a weird issue with node-vault when using the Google Cloud HTTPS Load Balancer as a proxy. The GCLB rejects GET/DELETE (and others) that it thinks shouldn’t have a body, although
this is not explicitly forbidden in the HTTP spec.

https://cloud.google.com/load-balancing/docs/https/#illegal_request_handling

The `node-vault` library passes an empty JSON object `{}` in generated GET requests (e.g. token/lookup-self) that have no params. This breaks the GCLB. The canonical `vault` CLI does not send the empty `{}` body, so it works fine...

```bash
curl -X GET -H "X-Vault-Token: REDACTED" https://my-vault.com/v1/auth/token/lookup-self
{"request_id":"eca75145-e57b-f6...,"renewable":true,"ttl":426941},"wrap_info":null,"warnings":null,"auth":null}
```

```bash
curl -X GET -H "X-Vault-Token: REDACTED" --data '{}' https://my-vault.com/v1/auth/token/lookup-self
<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 400 (Bad Request)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>400.</b> <ins>That’s an error.</ins>
  <p>Your client has issued a malformed or illegal request.  <ins>That’s all we know.</ins>
```