### PR TITLE
Improve consistency of handling methods that generate tokenResponse objects

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -556,6 +556,7 @@ module.exports = {
   tokenCreate: {
     method: 'POST',
     path: '/auth/token/create',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -601,6 +602,7 @@ module.exports = {
   tokenCreateOrphan: {
     method: 'POST',
     path: '/auth/token/create-orphan',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -646,6 +648,7 @@ module.exports = {
   tokenCreateRole: {
     method: 'POST',
     path: '/auth/token/create/{{role_name}}',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -823,6 +826,7 @@ module.exports = {
   tokenRenew: {
     method: 'POST',
     path: '/auth/token/renew',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',
@@ -842,6 +846,7 @@ module.exports = {
   tokenRenewSelf: {
     method: 'POST',
     path: '/auth/token/renew-self',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',


### PR DESCRIPTION
Following up on #93, there are a handful of methods that generate a tokenResponse object but were not marked as `tokenSource` methods.

Selfishly, I'm interested in `/auth/token/renew-self`. But I'm guessing there are others in the community who are interested in the other methods as well.