### PR TITLE
adding gcp login to auth types

### DIFF
--- a/features.md
+++ b/features.md
@@ -142,6 +142,11 @@
 `POST /sys/wrapping/unwrap`
 
 
+## vault.gcpLogin
+
+`POST /auth/{{mount_point}}{{^mount_point}}gcp{{/mount_point}}/login`
+
+
 ## vault.githubLogin
 
 `POST /auth/{{mount_point}}{{^mount_point}}github{{/mount_point}}/login`

--- a/src/commands.js
+++ b/src/commands.js
@@ -405,6 +405,26 @@ module.exports = {
       },
     },
   },
+  gcpLogin: {
+    method: 'POST',
+    path: '/auth/{{mount_point}}{{^mount_point}}gcp{{/mount_point}}/login',
+    tokenSource: true,
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          role: {
+            type: 'string',
+          },
+          jwt: {
+            type: 'string',
+          },
+        },
+        required: ['role', 'jwt'],
+      },
+      res: tokenResponse,
+    },
+  },
   githubLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}github{{/mount_point}}/login',


### PR DESCRIPTION
I've added the Google Cloud login as a supported auth type, per the API documentation here:

https://www.vaultproject.io/api/auth/gcp/index.html#login

Let me know if there's anything else I should add/amend!