### PR TITLE
kubernetesLogin: make it a token source

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -445,6 +445,7 @@ module.exports = {
   kubernetesLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}kubernetes{{/mount_point}}/login',
+    tokenSource: true,
     schema: {
       req: {
         type: 'object',


### PR DESCRIPTION
This PR builds on the work to add kubernetes login support (#92) and the ability to enable some commands to update client tokens (#93). This PR enables updating client tokens as part of the kubernetesLogin command.