### PR TITLE
approleSecretAccessorLookup() requires parameter 'secret_id_accessor'

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -1112,11 +1112,11 @@ module.exports = {
       req: {
         type: 'object',
         properties: {
-          secret_id: {
+          secret_id_accessor: {
             type: 'string',
           },
         },
-        required: ['secret_id'],
+        required: ['secret_id_accessor'],
       },
     },
   },


### PR DESCRIPTION
Fixes #116 