### PR TITLE
Fix schema definition of addApproleRole command.

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -978,32 +978,38 @@ module.exports = {
     path: '/auth/{{mount_point}}{{^mount_point}}approle{{/mount_point}}/role/{{role_name}}',
     schema: {
       req: {
-        bind_secret_id: {
-          type: 'boolean',
-        },
-        bound_cidr_list: {
-          type: 'string',
-        },
-        policies: {
-          type: 'string',
-        },
-        secret_id_num_uses: {
-          type: 'integer',
-        },
-        secret_id_ttl: {
-          type: 'integer',
-        },
-        token_num_uses: {
-          type: 'integer',
-        },
-        token_ttl: {
-          type: 'integer',
-        },
-        token_max_ttl: {
-          type: 'integer',
-        },
-        period: {
-          type: 'integer',
+        type: 'object',
+        properties: {
+          bind_secret_id: {
+            type: 'boolean',
+          },
+          bound_cidr_list: {
+            type: 'string',
+          },
+          policies: {
+            type: 'string',
+          },
+          secret_id_bound_cidrs: {
+            type: 'string',
+          },
+          secret_id_num_uses: {
+            type: 'integer',
+          },
+          secret_id_ttl: {
+            type: 'integer',
+          },
+          token_num_uses: {
+            type: 'integer',
+          },
+          token_ttl: {
+            type: 'integer',
+          },
+          token_max_ttl: {
+            type: 'integer',
+          },
+          period: {
+            type: 'integer',
+          },
         },
       },
     },


### PR DESCRIPTION
- Fix addApproleRole command schema definition by moving `req` properties under `properties` field.
- Additionally, add `secret_id_bound_cidrs` due to this deprecation warning:
> WARNING! The following warnings were returned from Vault:
 > * The "bound_cidr_list" parameter is deprecated and will be removed in favor
  of "secret_id_bound_cidrs".