### PR TITLE
fix: Avoid multiple `defaults` wrapping for request.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports = (config = {}) => {
   tv4 = config.tv4 || tv4;
   commands = config.commands || commands;
   mustache = config.mustache || mustache;
-  rp = (config['request-promise'] || rp).defaults({
+  const requestPromise = (config['request-promise'] || rp).defaults({
     json: true,
     resolveWithFullResponse: true,
     simple: false,
@@ -88,7 +88,7 @@ module.exports = (config = {}) => {
     options.uri = uri;
     debug(options.method, uri);
     if (options.json) debug(options.json);
-    return rp(options).then(client.handleVaultResponse);
+    return requestPromise(options).then(client.handleVaultResponse);
   };
 
   client.help = (path, requestOptions) => {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ let debug = require('debug')('node-vault');
 let tv4 = require('tv4');
 let commands = require('./commands.js');
 let mustache = require('mustache');
-let rp = require('request-promise-native');
+const rp = require('request-promise-native');
 
 class VaultError extends Error {}
 


### PR DESCRIPTION
A quick fix for #80, while we wait for v1.0.

Currently, every time you create a vault client, it adds another layer of wrapping to `request` that applies defaults, meaning for every client you create, it adds another frame to the stack when you make a request.


Fixes  #80.
