### PR TITLE
Ship index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "doc": "./docs"
   },
   "files": [
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "dependencies": {
     "debug": "3.1.0",


### PR DESCRIPTION
Extension of https://github.com/kr1sp1n/node-vault/pull/115

Not sure if index.d.ts needs to be moved to `src/`

Would also need an npm publish/release