### PR TITLE
Add aws authentication using the IAM method

### DIFF
--- a/features.md
+++ b/features.md
@@ -172,6 +172,11 @@
 `POST /auth/{{mount_point}}{{^mount_point}}kubernetes{{/mount_point}}/login`
 
 
+## vault.awsIamLogin
+
+`POST /auth/{{mount_point}}{{^mount_point}}aws{{/mount_point}}/login`
+
+
 ## vault.userpassLogin
 
 `POST /auth/{{mount_point}}{{^mount_point}}userpass{{/mount_point}}/login/{{username}}`

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ declare namespace NodeVault {
         githubLogin(options?: Option): Promise<any>;
         userpassLogin(options?: Option): Promise<any>;
         kubernetesLogin(options?: Option): Promise<any>;
+        awsIamLogin(options?: Option): Promise<any>;
         tokenAccessors(options?: Option): Promise<any>;
         tokenCreate(options?: Option): Promise<any>;
         tokenCreateOrphan(options?: Option): Promise<any>;

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "Charles Phillips (https://github.com/doublerebel)",
     "David Drewery (https://github.com/EXPEddrewery)",
     "Dustin (https://github.com/at88mph)",
+    "Jason Nguyen (https://github.com/gofightnguyen)",
     "Jeff Sisson (https://github.com/saranrapjs)",
     "Jonathan Bastnagel (https://github.com/inkadnb)",
     "Julian Amelung (https://github.com/julianbei)",
@@ -72,6 +73,7 @@
     "Mario Pareja (https://github.com/mpareja)",
     "Mark Frost (https://github.com/frostmar)",
     "Owen Farrell (https://github.com/owenfarrell)",
+    "Parker Johansen (https://github.com/auroq)",
     "Patrick Rainier Juen (https://github.com/uLan08)",
     "Phred Lane (https://github.com/fearphage)",
     "Ryan Lewis (https://github.com/ryanlewis)",
@@ -84,7 +86,9 @@
     "Tom Vogel (https://github.com/tavogel)",
     "Trevor Robinson (https://github.com/trevorr)",
     "Vineet Bhatia (https://github.com/firefoxNX)",
-    "Vladyslav Mashkin (https://github.com/jsdream)"
+    "Vladyslav Mashkin (https://github.com/jsdream)",
+    "Wes Novack (https://github.com/wes-novack)",
+    "Zach Lintz (https://github.com/zlintz)"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/commands.js
+++ b/src/commands.js
@@ -474,6 +474,41 @@ module.exports = {
       res: tokenResponse,
     },
   },
+  awsIamLogin: {
+    method: 'POST',
+    path: '/auth/{{mount_point}}{{^mount_point}}aws{{/mount_point}}/login',
+    tokenSource: true,
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          role: {
+            type: 'string',
+          },
+          iam_http_request_method: {
+            type: 'string',
+          },
+          iam_request_url: {
+            type: 'string',
+          },
+          iam_request_body: {
+            type: 'string',
+          },
+          iam_request_headers: {
+            type: 'string',
+          },
+        },
+        required: [
+          'role',
+          'iam_http_request_method',
+          'iam_request_url',
+          'iam_request_body',
+          'iam_request_headers',
+        ],
+      },
+      res: tokenResponse,
+    },
+  },
   userpassLogin: {
     method: 'POST',
     path: '/auth/{{mount_point}}{{^mount_point}}userpass{{/mount_point}}/login/{{username}}',


### PR DESCRIPTION
This adds AWS authentication. It uses the IAM method (in vault) specifically not EC2.

Co-Authored-By: Parker Johansen <parker-johansen@pluralsight.com>
Co-Authored-By: Jason Nguyen <jason-nguyen@pluralsight.com>
Co-Authored-By: Wes Novack <wes-novack@pluralsight.com>