### PR TITLE
Fix socks proxy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,15 @@ node example/policies.js
 
 To connect to a vault server in a private network with a bastion host, you'll need to first open a connection:
 ```bash
-ssh -D <socks4Port> bastion.example.com
+ssh -D <socksPort> bastion.example.com
 ```
 
 ```javascript
 const SocksProxyAgent = require('socks-proxy-agent');
-const agent = new SocksProxyAgent(`socks://127.0.0.1:${socks4Port}`, true);
+const agent = new SocksProxyAgent(`socks5://127.0.0.1:${socksPort}`);
 const options = {
   apiVersion: 'v1',
-  rpOptions: {
+  rpDefaults: {
     agent,
   },
 };


### PR DESCRIPTION
I noticed that the proxy documentation was incorrect. The docs recommend using the option `rpOptions` but `rpDefaults` is what is checked in code. I think it probably makes more sense to use `rpOptions` in a config object, however that would be a breaking API change for whoever is using `rpDefaults` right now.

I also removed reference to socks4, as 5 is a better protocol and most ssh clients ship with that now. Here's an [example](https://www.npmjs.com/package/socks-proxy-agent#https-module-example) from the socks-proxy-agent docs. I don't think we need the second boolean arg either.