### PR TITLE
fix: add missing ldap/okta/radius login types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,9 @@ declare namespace NodeVault {
         gcpLogin(options?: Option): Promise<any>;
         githubLogin(options?: Option): Promise<any>;
         userpassLogin(options?: Option): Promise<any>;
+        ldapLogin(options?: Option): Promise<any>;
+        oktaLogin(options?: Option): Promise<any>;
+        radiusLogin(options?: Option): Promise<any>;
         kubernetesLogin(options?: Option): Promise<any>;
         awsIamLogin(options?: Option): Promise<any>;
         tokenAccessors(options?: Option): Promise<any>;


### PR DESCRIPTION
Hello, found these 3 missing login types for `ldapLogin`,  `oktaLogin `,  `radiusLogin `. I had a quick look in login types and didn't find anything else missing. 