### PR TITLE
Added missing types for login methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,9 @@ declare namespace NodeVault {
         userpassLogin(options?: Option): Promise<any>;
         kubernetesLogin(options?: Option): Promise<any>;
         awsIamLogin(options?: Option): Promise<any>;
+        ldapLogin(options?: Option): Promise<any>;
+        oktaLogin(options?: Option): Promise<any>;
+        radiusLogin(options?: Option): Promise<any>;
         tokenAccessors(options?: Option): Promise<any>;
         tokenCreate(options?: Option): Promise<any>;
         tokenCreateOrphan(options?: Option): Promise<any>;


### PR DESCRIPTION
While trying to implement the `oktaLogin` in a typescript project, I noticed that the `ldapLogin`, `oktaLogin`, `radiusLogin` types were missing