### PR TITLE
Add raftJoin and recovery options to init

### DIFF
--- a/features.md
+++ b/features.md
@@ -72,6 +72,11 @@
 `GET /{{databasePath}}/creds/{{name}}`
 
 
+## vault.raftJoin
+
+`POST /sys/storage/raft/join`
+
+
 ## vault.unmount
 
 `DELETE /sys/mounts/{{mount_point}}`

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "contributors": [
     "Adam Kelsall (https://github.com/adamkelsall)",
     "Alex Early (https://github.com/aearly)",
+    "Benjamin Neumann (https://github.com/naimo84)",
     "Brandon Ros (https://github.com/brandonros)",
     "Charles Phillips (https://github.com/doublerebel)",
     "David Drewery (https://github.com/EXPEddrewery)",

--- a/src/commands.js
+++ b/src/commands.js
@@ -300,6 +300,10 @@ module.exports = {
     method: 'GET',
     path: '/{{databasePath}}/creds/{{name}}',
   },
+  raftJoin:{
+    method: 'POST',
+    path: '/sys/storage/raft/join'
+  },
   unmount: {
     method: 'DELETE',
     path: '/sys/mounts/{{mount_point}}',

--- a/src/commands.js
+++ b/src/commands.js
@@ -101,6 +101,14 @@ module.exports = {
             type: 'integer',
             minimum: 1,
           },
+          recovery_shares: {
+            type: 'integer',
+            minimum: 1,
+          },
+          recovery_threshold: {
+            type: 'integer',
+            minimum: 1,
+          },
           pgp_keys: {
             type: 'array',
             items: {
@@ -108,8 +116,7 @@ module.exports = {
             },
             uniqueItems: true,
           },
-        },
-        required: ['secret_shares', 'secret_threshold'],
+        },        
       },
       res: {
         type: 'object',


### PR DESCRIPTION
At work we're using two vaults. One for autounseal and one for the "real data".
The one for autounseal can be initialized as usual with secret_shares, the data one has to be initalized with recovery_shares options. This one is also a RaftCluster, so I added raft join.

https://www.vaultproject.io/api-docs/system/storage/raft
https://www.vaultproject.io/api/system/init#recovery_shares

Greets,
Benjamin